### PR TITLE
Add a `--debug` flag to the CSV generator

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
       - name: "Set up Python"
-        uses: "actions/setup-python@v2"
+        uses: "actions/setup-python@v5"
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: "install linting tooling"
         continue-on-error: true
         run: |

--- a/.github/workflows/unit-tests-all.yml
+++ b/.github/workflows/unit-tests-all.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
         include:
           #
@@ -21,37 +21,57 @@ jobs:
           # Example formatting: 3.11.0-alpha.1, 3.9.0-beta.8, 3.10.0-rc.3
           #
           - os: ubuntu-latest
-            python-version: "3.11.0"
+            python-version: "3.13"
             experimental: true
           - os: macos-latest
-            python-version: "3.11.0"
+            python-version: "3.13"
+            experimental: true
+          - os: windows-latest
+            python-version: "3.13"
             experimental: true
     steps:
       - name: "check out repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
         with:
           submodules: 'true'
       - name: "set up python ${{ matrix.python-version }}"
-        uses: "actions/setup-python@v2"
+        uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "get pip cache dir"
         id: "pip-cache"
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      - name: "cache pip packages"
-        uses: "actions/cache@v2"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: "show outputs.dir"
+        run: echo "${{ steps.pip-cache.outputs.dir }}" && echo "${{ runner.os }}"
+      - name: "install magic on macos"
+        if: matrix.os == 'macos-latest'
+        run: |
+            brew install libmagic
+      - name: "cache pip packages (windows)"
+        uses: "actions/cache@v4"
+        if: matrix.os == 'windows-latest'
+        with:
+          path: ~\AppData\Local\pip
+          key: "${{ runner.os }}-pip-${{ hashFiles('**/local.txt') }}"
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: "cache pip packages (all platforms)"
+        uses: "actions/cache@v4"
+        if: matrix.os != 'windows-latest'
         with:
           path: "${{ steps.pip-cache.outputs.dir }}"
-          key: "${{ runner.os }}-pip-${{ hashFiles('**/base.txt', '**/local.txt') }}"
+          key: "${{ runner.os }}-pip-${{ hashFiles('**/local.txt') }}"
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: "install tox"
         run: |
           python -m pip install --upgrade pip
-          pip install tox
-      - name: "run tox"
-        env:
-          TOXENV: py3
-        run: |
-          tox
+          pip install tox-gh-actions
+          python -m pip install -r requirements/local.txt
+      - name: "run tox (all platforms)"
+        if: matrix.os != 'windows-latest'
+        run: tox
+      - name: "run pytest (windows)"
+        if: matrix.os == 'windows-latest'
+        run: pytest -c pytest.ini tests/

--- a/.pylintrc
+++ b/.pylintrc
@@ -38,3 +38,4 @@ ignore-paths=
 disable =
     C0301,      # line too long.
     R0903,      # too few public methods.
+    R0801,      # similar lines across files.

--- a/src/anz_rosetta_csv/anz_rosetta_csv.py
+++ b/src/anz_rosetta_csv/anz_rosetta_csv.py
@@ -1,5 +1,8 @@
 """Archives New Zealand Rosetta CSV Generator."""
 
+# pylint: disable=C0103; # upper-case naming conventions for constants.
+# pylint: disable=W0603; # global used for logger.
+
 import argparse
 import configparser as ConfigParser
 import logging
@@ -14,17 +17,23 @@ except ModuleNotFoundError:
     except ModuleNotFoundError:
         from anz_rosetta_csv.rosetta_csv_generator import RosettaCSVGenerator
 
+logger = None
 
-logger = logging.getLogger(__name__)
 
-logging.basicConfig(
-    format="%(asctime)-15s %(levelname)s :: %(filename)s:%(lineno)s:%(funcName)s() :: %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-    level="INFO",
-)
-
-# Default to UTC time.
-logging.Formatter.converter = time.gmtime
+def init_logging(debug: bool):
+    """Initialize logging."""
+    logging.basicConfig(
+        format="%(asctime)-15s %(levelname)s :: %(filename)s:%(lineno)s:%(funcName)s() :: %(message)s",  # noqa: E501
+        datefmt="%Y-%m-%d %H:%M:%S",
+        level=logging.DEBUG if debug else logging.INFO,
+        handlers=[
+            logging.StreamHandler(),
+        ],
+    )
+    logging.Formatter.converter = time.gmtime
+    global logger
+    logger = logging.getLogger(__name__)
+    logger.debug("debug logging is configured")
 
 
 def main():
@@ -62,12 +71,21 @@ def main():
         default=False,
         required=False,
     )
+    parser.add_argument(
+        "--debug",
+        help="Use DEBUG mode for more logging",
+        action="store_true",
+    )
 
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit()
 
     args = parser.parse_args()
+
+    # Initialize logging.
+    init_logging(args.debug)
+
     if args.args:
         config = ConfigParser.RawConfigParser()
         config.read(args.args)

--- a/src/anz_rosetta_csv/import_sheet_generator.py
+++ b/src/anz_rosetta_csv/import_sheet_generator.py
@@ -11,9 +11,8 @@ class ImportSheetGenerator:
         return title.rsplit(".", 1)[
             0
         ].rstrip()  # split once at full-stop (assumptuon 'ext' follows)
-        
-        # for processing transfers where the record name provided is full file name WITH file extension: 
-        # 1) un-comment the line below (starts with "return title.rstrip()") and 
+
+        # for processing transfers where the record name provided is full file name WITH file extension:
+        # 1) un-comment the line below (starts with "return title.rstrip()") and
         # 2) comment-out 3 lines above (starting with "return")
         # return title.rstrip()  # split once at full-stop (assumptuon 'ext' follows)
-

--- a/src/anz_rosetta_csv/rosetta_csv_generator.py
+++ b/src/anz_rosetta_csv/rosetta_csv_generator.py
@@ -1,6 +1,9 @@
 """Archives New Zealand Rosetta CSV Generator."""
 
-# pylint: disable=R1710,R0902,R0913,R0912
+# pylint: disable=R0902; # too-many instance attributes.
+# pylint: disable=R0913; # too-many arguments.
+# pylint: disable=R1710; # all-return statements must return.
+# pylint: disable=R0912; # too-many branches.
 
 import configparser as ConfigParser
 import logging
@@ -49,12 +52,50 @@ def ingest_path_from_droid_row(droid_row: dict, path_mask: str) -> str:
 def find_path_from_subseries(
     record_title: str, droid_row: dict, lc_sub_series: str, series_mask: str
 ) -> bool:
-    """Determine the path to add to the CSV from its sub-series"""
+    """Determine the path to add to the CSV from its sub-series.
+
+    Example:
+
+        pathmask is: "R:\\Digitised\\Wellington\\mock_transfer\\" (we zip the contents from what is remaining)
+
+        droid path: "R:\\Digitised\\Wellington\\mock_transfer\\2006-2007 Project Programme\\2006-07 Project Programme Submission to MoU\\2006-07 Rules Bid_ (🥬) Letter.doc"
+
+        desired subseries: "Project Programme\\"
+
+        given the desired subseries we need to strip the following from the DROID path: "R:\\Digitised\\Wellington\\mock_transfer\\2006-2007 "
+
+        the droid path now looks like: "Project Programme\\2006-07 Project Programme Submission to MoU\\2006-07 Rules Bid_ (🥬) Letter.doc"
+
+        the file name is removed (this sounds counter-intuitive but it can only be removed IF it matches) leaving: "Project Programme\\2006-07 Project Programme Submission to MoU\\"
+
+        which is compared to the list control: "Project Programme\\2006-07 Project Programme Submission to MoU"
+
+        we now do the comparison: "Project Programme\\2006-07 Project Programme Submission to MoU\\" (calculated from the DROID sheet) is equal to "Project Programme\\2006-07 Project Programme Submission to MoU" (in the list control)
+
+    """
+
     file_name = droid_row["NAME"].strip()
     file_path = droid_row["FILE_PATH"].strip()
+
+    logger.debug("DROID row filename: '%s'", file_path)
+    logger.debug("DROID row path: '%s'", file_path)
+
     if record_title.strip() not in file_path:
+        logger.error("record title '%s' not in DROID filename", record_title)
         return False
+
+    logger.debug("list control sub-series mask: '%s'", series_mask)
+    logger.debug("record title: '%s'", record_title)
+
     compare = file_path.replace(file_name, "").replace(series_mask, "", 1).strip()[:-1]
+
+    logger.debug(
+        "string to compare with sub-series: '%s' and sub_series: '%s' matches: '%s'",
+        compare,
+        lc_sub_series,
+        (compare == lc_sub_series),
+    )
+
     return compare == lc_sub_series
 
 

--- a/src/anz_rosetta_csv/rosetta_csv_generator.py
+++ b/src/anz_rosetta_csv/rosetta_csv_generator.py
@@ -131,7 +131,7 @@ class RosettaCSVGenerator:
 
         logging.info("reading app config from '%s'", configfile)
         self.config = ConfigParser.RawConfigParser()
-        self.config.read(configfile)
+        self.config.read(configfile, encoding="utf-8")
 
         self.droidcsv = droidcsv
         self.exportsheet = exportsheet

--- a/src/anz_rosetta_csv/rosetta_csv_sections_class.py
+++ b/src/anz_rosetta_csv/rosetta_csv_sections_class.py
@@ -16,7 +16,7 @@ class RosettaCSVSections:
     def __init__(self, configfile):
         logging.info("reading app config from '%s'", configfile)
         self.config = ConfigParser.RawConfigParser()
-        self.config.read(configfile)
+        self.config.read(configfile, encoding="utf-8")
 
         # Configure via CFG to avoid users having to edit code
         sections = []

--- a/tests/test_import_generator.py
+++ b/tests/test_import_generator.py
@@ -519,11 +519,11 @@ def test_csv_generation(tmp_path):
     list_control_file = tmp_dir / "lc.csv"
     prov_file = tmp_dir / "prov.notes"
 
-    config_file.write_text(config.strip().lstrip())
-    schema_file.write_text(schema.strip().lstrip())
-    droid_report.write_text(droid_csv.strip().lstrip())
-    list_control_file.write_text(list_control.strip().lstrip())
-    prov_file.write_text(prov.strip().lstrip())
+    config_file.write_text(config.strip().lstrip(), encoding="utf-8")
+    schema_file.write_text(schema.strip().lstrip(), encoding="utf-8")
+    droid_report.write_text(droid_csv.strip().lstrip(), encoding="utf-8")
+    list_control_file.write_text(list_control.strip().lstrip(), encoding="utf-8")
+    prov_file.write_text(prov.strip().lstrip(), encoding="utf-8")
 
     csvgen = RosettaCSVGenerator(
         droid_report,


### PR DESCRIPTION
The debug flag means we can switch on more verbose logging when it is needed. It provides a way to give more information about processes without always printing out too much information.

When the `--debug` flag is used you get output as follows (this is in the sub-series check):

```text
2025-11-24 19:38:06 DEBUG :: rosetta_csv_generator.py:77:find_path_from_subseries() :: DROID row filename: 'C:\Source\git\archives-nz-rosetta-csv-ingest-master\Ross\this_is_dup.xlsx'
2025-11-24 19:38:06 DEBUG :: rosetta_csv_generator.py:78:find_path_from_subseries() :: DROID row path: 'C:\Source\git\archives-nz-rosetta-csv-ingest-master\Ross\this_is_dup.xlsx'
2025-11-24 19:38:06 DEBUG :: rosetta_csv_generator.py:84:find_path_from_subseries() :: list control sub-series mask: ''
2025-11-24 19:38:06 DEBUG :: rosetta_csv_generator.py:85:find_path_from_subseries() :: record title: 'this_is_dup'
2025-11-24 19:38:06 DEBUG :: rosetta_csv_generator.py:89:find_path_from_subseries() :: string to compare with sub-series: 'C:\Source\git\archives-nz-rosetta-csv-ingest-master\Ross' and sub_series: 'C:\Source\git\archives-nz-rosetta-csv-ingest-master\Ross' matches: 'True'
```

You can see where in the code the DEBUG log is like other logs. 

**NB.** the `pylint: disable=` values are just cleaning up what was already there (and need some care and attention when the code can be looked at more thoroughly) and two new ones that help make the dev experience easier for the PR. 

You can also add your own debug logging, paying attention to the placeholders, you might want to put in your own logs to learn more, e.g.

```python
# one placeholder
logger.debug("output a number: %s", a_number)
# two placeholders
logger.debug("placeholder 1: '%s' placeholder 2: '%s', value_1, value_2)
```